### PR TITLE
Hopefully better sorting, limit of 30

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,17 +34,13 @@ fetch(`https://api.jikan.moe/v3/search/anime?q=${query}`)
     //console.log([data])
 
     //console.log(data.results[0]);
-    let bunch = data.results.slice(0, 30);
+    const bunch = data.results.slice(0, 30);
     let status = "";
     let PTitle = "";
 
     if (arg[0] !== undefined) {
       arg[0] = arg[0].toLowerCase();
     }
-
-    let matches = bunch.filter((item) => item.title.toLowerCase().includes(arg[0]));
-    let notMatches = bunch.filter((item) => !item.title.toLowerCase().includes(arg[0]));
-    bunch = matches.concat(notMatches);
 
     bunch.map((item) => {
       //console.log(item.title);

--- a/index.js
+++ b/index.js
@@ -1,12 +1,14 @@
 #!/usr/bin/env node
 
 const fetch = require("node-fetch");
+const pjson = require("./package.json");
+
 //const query = "Naruto";
 let query = process.argv.slice(2,process.argv.length);
 query = query.join();
 //console.log(query.split(','));
 const arg = query.split(",");
-//console.log(0]);
+//console.log(arg[0]);
 
 var Table = require("cli-table3");
 var table = new Table({
@@ -14,16 +16,46 @@ var table = new Table({
   colWidths: [46, 11],
 });
 
+// For font colors
 const chalk = require("chalk");
+const greenText = "\x1b[32m";
+const resetFont = "\x1b[0m";
+const cyanText = "\x1b[36m";
 
-if (arg[0] === "help" || arg[0] === "-h") {
-  console.log(
-    chalk.redBright(
-      "You just need to type anime and then the actual\nof the anime that you want to search but with \nevery word having the first letter as the \ncapital letter"
-    )
-  );
-  console.log(chalk.greenBright("For example: anime Boku No Hero"));
+if (arg[0] === "--help" || arg[0] === "-h") {
+  console.log(`
+NAME
+	${cyanText}anime-cli: command line application to fetch anime details${resetFont}
+
+USAGE
+	${cyanText}anime-cli [ <anime name>  |  arguments ]
+	anime-cli [ <anime name> |  -help  | --h ...]${resetFont}
+
+OPTIONS
+	<anime name>
+		The name of the anime whose information you would
+		like to fetch
+		${greenText}eg: anime-cli Naruto${resetFont}
+	
+	help, --h
+		view this information
+		${greenText}eg: anime-cli -help${resetFont}
+
+	version, --v
+		view the version number of the anime-cli app
+		${greenText}eg: anime-cli -version${resetFont}
+
+DESCRIPION
+	anime-cli is a command line application that can be used to
+	fetch information regarding the user-queried anime, like
+	number of episodes, type of anime and it's airing status.
+	  `);
   return;
+}
+
+if(arg[0] === "--version" || arg[0] === "-v") {
+	console.log(chalk.cyanBright(`anime-cli\nversion: ${pjson.version}\n`))
+	return;
 }
 
 //console.log(table.toString());

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const fetch = require("node-fetch");
 //const query = "Naruto";
-let query = process.argv;
+let query = process.argv.slice(2,process.argv.length);
 query = query.join();
 //console.log(query.split(','));
 const arg = query.split(",");

--- a/index.js
+++ b/index.js
@@ -34,13 +34,17 @@ fetch(`https://api.jikan.moe/v3/search/anime?q=${query}`)
     //console.log([data])
 
     //console.log(data.results[0]);
-    const bunch = data.results;
+    let bunch = data.results.slice(0, 30);
     let status = "";
     let PTitle = "";
 
     if (arg[2] !== undefined) {
       arg[2] = arg[2].toLowerCase();
     }
+
+    let matches = bunch.filter((item) => item.title.toLowerCase().includes(arg[2]));
+    let notMatches = bunch.filter((item) => !item.title.toLowerCase().includes(arg[2]));
+    bunch = matches.concat(notMatches);
 
     bunch.map((item) => {
       //console.log(item.title);

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ let query = process.argv.slice(2,process.argv.length);
 query = query.join();
 //console.log(query.split(','));
 const arg = query.split(",");
-//console.log(arg[2]);
+//console.log(0]);
 
 var Table = require("cli-table3");
 var table = new Table({
@@ -16,7 +16,7 @@ var table = new Table({
 
 const chalk = require("chalk");
 
-if (arg[2] === "help" || arg[2] === "-h") {
+if (arg[0] === "help" || arg[0] === "-h") {
   console.log(
     chalk.redBright(
       "You just need to type anime and then the actual\nof the anime that you want to search but with \nevery word having the first letter as the \ncapital letter"
@@ -38,18 +38,18 @@ fetch(`https://api.jikan.moe/v3/search/anime?q=${query}`)
     let status = "";
     let PTitle = "";
 
-    if (arg[2] !== undefined) {
-      arg[2] = arg[2].toLowerCase();
+    if (arg[0] !== undefined) {
+      arg[0] = arg[0].toLowerCase();
     }
 
-    let matches = bunch.filter((item) => item.title.toLowerCase().includes(arg[2]));
-    let notMatches = bunch.filter((item) => !item.title.toLowerCase().includes(arg[2]));
+    let matches = bunch.filter((item) => item.title.toLowerCase().includes(arg[0]));
+    let notMatches = bunch.filter((item) => !item.title.toLowerCase().includes(arg[0]));
     bunch = matches.concat(notMatches);
 
     bunch.map((item) => {
       //console.log(item.title);
 
-      if (item.title.toLowerCase().includes(arg[2])) {
+      if (item.title.toLowerCase().includes(arg[0])) {
         PTitle = chalk.bold.green;
       } else {
         PTitle = chalk.bold.white;


### PR DESCRIPTION
- Before, file path and node path were also send to the API which searched for it at MAL. That caused weird sorting, should be fixed now. Because MAL has a 100 character search limit, that also fixes the issue of receiving an error when searching for a longer title (eg Shigatsu wa kimi no Uso) while running the the program from a deeper directory. This path was also send to MAL and could fill up the 100 characters completely or almost completely

- Limit to 30 results